### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   sonarqube:
     name: SonarQube


### PR DESCRIPTION
Potential fix for [https://github.com/teandt/narou_api_check/security/code-scanning/1](https://github.com/teandt/narou_api_check/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/main.yml` at the workflow root so it applies to all jobs unless overridden. For this workflow, the least-privilege baseline is `contents: read`, which is sufficient for `actions/checkout` and the SonarQube scan usage shown. This change does not alter intended functionality but documents and enforces minimum token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
